### PR TITLE
Enable city state editing

### DIFF
--- a/php/actualizar_registro.php
+++ b/php/actualizar_registro.php
@@ -34,9 +34,10 @@ if ($tipo === 'precio') {
     $id = $_POST['id'] ?? '';
     $imp_adulto = $_POST['impuesto_adulto'] ?? 0;
     $imp_infantil = $_POST['impuesto_infantil'] ?? 0;
+    $estado = isset($_POST['estado']) ? intval($_POST['estado']) : 0;
 
-    $query = $mysqli->prepare("UPDATE ciudad SET impuesto_adulto=?, impuesto_infantil=? WHERE id=?");
-    $query->bind_param("ddi", $imp_adulto, $imp_infantil, $id);
+    $query = $mysqli->prepare("UPDATE ciudad SET impuesto_adulto=?, impuesto_infantil=?, estado=? WHERE id=?");
+    $query->bind_param("ddii", $imp_adulto, $imp_infantil, $estado, $id);
 
     if ($query->execute()) {
         echo json_encode(['success' => true]);

--- a/php/editar_registro.php
+++ b/php/editar_registro.php
@@ -78,6 +78,13 @@ if ($tipo === 'precio') {
       <label>Impuesto Infantil</label>
       <input type="number" step="0.01" class="form-control" name="impuesto_infantil" value="<?php echo $dato['impuesto_infantil']; ?>">
     </div>
+    <div class="mb-3">
+      <label>Estado</label>
+      <select class="form-select" name="estado">
+        <option value="1" <?php echo $dato['estado'] == 1 ? 'selected' : ''; ?>>Activa</option>
+        <option value="0" <?php echo $dato['estado'] == 0 ? 'selected' : ''; ?>>Inactiva</option>
+      </select>
+    </div>
   </form>
 
 <?php

--- a/php/precios.php
+++ b/php/precios.php
@@ -58,6 +58,7 @@ echo "<div class='d-flex align-items-center gap-2 mt-4'>
   <th>Ciudad</th>
   <th>Impuesto Adulto</th>
   <th>Impuesto Infantil</th>
+  <th>Estado</th>
   <th>Editar</th>
 </tr>
 </thead><tbody>";
@@ -67,6 +68,7 @@ while ($row = $ciudades->fetch_assoc()) {
     <td>{$row['nombre']}</td>
     <td>{$row['impuesto_adulto']}</td>
     <td>{$row['impuesto_infantil']}</td>
+    <td>" . ($row['estado'] == 1 ? 'Activa' : 'Inactiva') . "</td>
     <td>" . btnEditar("ciudad", $row['id']) . "</td>
   </tr>";
 }


### PR DESCRIPTION
## Summary
- add estado dropdown to edit-city form
- save estado value when updating city
- display estado in the city list

## Testing
- `php -l php/editar_registro.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842ea83c6c8832287c6d0e42fae7e5f