### PR TITLE
Enable active/inactive user editing

### DIFF
--- a/admin_usuarios.html
+++ b/admin_usuarios.html
@@ -106,6 +106,13 @@
           <label class="form-label">Ciudad</label>
           <select id="editCiudad" class="form-select"></select>
         </div>
+        <div class="mb-2">
+          <label class="form-label">Estado</label>
+          <select id="editEstado" class="form-select">
+            <option value="1">Activo</option>
+            <option value="0">Inactivo</option>
+          </select>
+        </div>
       </div>
       <div class="modal-footer">
         <button class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
@@ -136,15 +143,16 @@ function cargarUsuarios() {
   })
   .then(r => r.json())
   .then(data => {
-    let html = `<table class='table table-striped'><thead><tr><th>RUT</th><th>Nombre</th><th>Usuario</th><th>Correo</th><th>Tipo</th><th>Ciudad</th><th>Acciones</th></tr></thead><tbody>`;
+    let html = `<table class='table table-striped'><thead><tr><th>RUT</th><th>Nombre</th><th>Usuario</th><th>Correo</th><th>Tipo</th><th>Ciudad</th><th>Estado</th><th>Acciones</th></tr></thead><tbody>`;
     data.forEach(u => {
-      html += `<tr>
+      html += `<tr class="${u.estado == 1 ? 'table-success' : 'table-danger'}">
         <td>${u.rut}</td>
         <td>${u.name}</td>
         <td>${u.user_name}</td>
         <td>${u.mail}</td>
         <td>${tipoTexto(u.type)}</td>
         <td>${u.ciudad_nombre || 'Sin asignar'}</td>
+        <td><span class="badge ${u.estado == 1 ? 'bg-success' : 'bg-danger'}">${u.estado == 1 ? 'Activo' : 'Inactivo'}</span></td>
         <td>
           <button class='btn btn-warning btn-sm' onclick='editarUsuario(${JSON.stringify(u)})'><i class='bi bi-pencil'></i></button>
           <button class='btn btn-danger btn-sm' onclick='eliminarUsuario("${u.rut}")'><i class='bi bi-trash'></i></button>
@@ -184,6 +192,7 @@ function editarUsuario(u) {
   document.getElementById('editMail').value = u.mail;
   document.getElementById('editTipo').value = u.type;
   cargarCiudades(u.ciudad);
+  document.getElementById('editEstado').value = u.estado;
   new bootstrap.Modal(document.getElementById('modalUsuario')).show();
 }
 
@@ -197,6 +206,7 @@ async function abrirModalAgregar() {
   document.getElementById('editMail').value = '';
   document.getElementById('editTipo').value = '0';
   await cargarCiudades();
+  document.getElementById('editEstado').value = '1';
   new bootstrap.Modal(document.getElementById('modalUsuario')).show();
 }
 
@@ -208,7 +218,8 @@ function guardarCambios() {
     usuario: document.getElementById('editUsuario').value,
     mail: document.getElementById('editMail').value,
     tipo: parseInt(document.getElementById('editTipo').value),
-    ciudad: parseInt(document.getElementById('editCiudad').value)
+    ciudad: parseInt(document.getElementById('editCiudad').value),
+    estado: parseInt(document.getElementById('editEstado').value)
   };
 
   fetch('php/usuarios.php', {

--- a/php/usuarios.php
+++ b/php/usuarios.php
@@ -35,10 +35,11 @@ switch ($accion) {
     $mail = $input['mail'];
     $tipo = $input['tipo'];
     $ciudad = $input['ciudad'];
+    $estado = isset($input['estado']) ? (int)$input['estado'] : 1;
     $pass = password_hash('123456', PASSWORD_DEFAULT);
-    
-    $stmt = $mysqli->prepare("INSERT INTO user (rut, name, user_name, pass, mail, type, ciudad) VALUES (?, ?, ?, ?, ?, ?, ?)");
-    $stmt->bind_param("sssssis", $rut, $nombre, $usuario, $pass, $mail, $tipo, $ciudad);
+
+    $stmt = $mysqli->prepare("INSERT INTO user (rut, name, user_name, pass, mail, type, ciudad, estado) VALUES (?, ?, ?, ?, ?, ?, ?, ?)");
+    $stmt->bind_param("sssssiii", $rut, $nombre, $usuario, $pass, $mail, $tipo, $ciudad, $estado);
     if ($stmt->execute()) {
       echo json_encode(["success" => true]);
     } else {
@@ -53,9 +54,10 @@ switch ($accion) {
     $mail = $input['mail'];
     $tipo = $input['tipo'];
     $ciudad = $input['ciudad'];
+    $estado = isset($input['estado']) ? (int)$input['estado'] : 1;
 
-    $stmt = $mysqli->prepare("UPDATE user SET name=?, user_name=?, mail=?, type=?, ciudad=? WHERE rut=?");
-    $stmt->bind_param("sssiss", $nombre, $usuario, $mail, $tipo, $ciudad, $rut);
+    $stmt = $mysqli->prepare("UPDATE user SET name=?, user_name=?, mail=?, type=?, ciudad=?, estado=? WHERE rut=?");
+    $stmt->bind_param("sssiiis", $nombre, $usuario, $mail, $tipo, $ciudad, $estado, $rut);
     if ($stmt->execute()) {
       echo json_encode(["success" => true]);
     } else {


### PR DESCRIPTION
## Summary
- add Estado dropdown in admin user modal
- display Estado column in user table
- support editing/adding estado via JS
- update PHP endpoints to store estado
- highlight rows green for active users and red for inactive

## Testing
- `php -l php/usuarios.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fb3c4bac8322b4306e41bfee64c4